### PR TITLE
fix: Doc update, correct public input

### DIFF
--- a/state_bridge_l2/world_id_state_bridge/src/stark_world_id/world_id_bridge/world_id_bridge.cairo
+++ b/state_bridge_l2/world_id_state_bridge/src/stark_world_id/world_id_bridge/world_id_bridge.cairo
@@ -201,8 +201,8 @@ pub mod WorldID {
         ///     }
         ///     The public inputs are in order:
         ///     * 'root' - The root of the Merkle tree
-        ///     * 'signalHash' - A keccak256 hash of the Semaphore signal
         ///     * 'nullifierHash' - The nullifier hash
+        ///     * 'signalHash' - A keccak256 hash of the Semaphore signal
         ///     * 'externalNullifierHash' - A keccak256 hash of the external nullifier
         ///
         /// * 'mpcheck_hint' - The check hint for BN254


### PR DESCRIPTION
-fix: Worldcoin's IWorldID interface ordering is different for public inputs. See https://github.com/worldcoin/world-id-contracts/blob/main/src/interfaces/IWorldID.sol.